### PR TITLE
Improve resume site visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,85 +1,107 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Кембаев Мухамеджан Касенулы - Resume</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
-  <header>
-    <div class="container">
-      <h1>Кембаев Мухамеджан Касенулы</h1>
-      <p class="contact-info">г.Астана, Казахстан &middot; Родился 28.05.2004</p>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Кембаев Мухамеджан Касенулы - Resume</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <img
+          class="profile-photo"
+          src="IMG_20230430_110132.jpg"
+          alt="Profile Photo"
+        />
+        <h1>Кембаев Мухамеджан Касенулы</h1>
+        <p class="contact-info">
+          г.Астана, Казахстан &middot; Родился 28.05.2004
+        </p>
+      </div>
+    </header>
 
-  <main class="container">
-    <section>
-      <h2>Professional Summary</h2>
-      <p>Техник-программист, специализирующийся на глубоких нейронных сетях и машинном обучении. Ищу работу во второй половине дня для совмещения с учебой.</p>
-    </section>
+    <main class="container">
+      <section>
+        <h2>Professional Summary</h2>
+        <p>
+          Техник-программист, специализирующийся на глубоких нейронных сетях и
+          машинном обучении. Ищу работу во второй половине дня для совмещения с
+          учебой.
+        </p>
+      </section>
 
-    <section>
-      <h2>Experience</h2>
-      <div class="job">
-        <h3>Центр квалификаций ГКП на ПХВ «Высший колледж Astana Polytechnic»</h3>
-        <span class="date">Практика, 2023</span>
-        <ul>
-          <li>Стажёр, выполнение учебных задач в сфере IT</li>
+      <section>
+        <h2>Experience</h2>
+        <div class="job">
+          <h3>
+            Центр квалификаций ГКП на ПХВ «Высший колледж Astana Polytechnic»
+          </h3>
+          <span class="date">Практика, 2023</span>
+          <ul>
+            <li>Стажёр, выполнение учебных задач в сфере IT</li>
+          </ul>
+        </div>
+      </section>
+      <section>
+        <h2>Education</h2>
+        <div class="school">
+          <h3>Высший колледж «Astana Polytechnic»</h3>
+          <span class="date">2020 – 2024, техник-программист</span>
+        </div>
+        <div class="school">
+          <h3>AITU</h3>
+          <span class="date">2024 – 2027</span>
+        </div>
+        <div class="school">
+          <h3>Дополнительные курсы</h3>
+          <ul>
+            <li>Coursera: Machine Learning by Andrew Ng</li>
+            <li>Reinforcement Learning by University of Alberta</li>
+            <li>Convolution NN, Sequence Models by DeepLearning.ai</li>
+            <li>Сертификаты Udemy, Datacamp</li>
+          </ul>
+        </div>
+      </section>
+      <section>
+        <h2>Skills</h2>
+        <ul class="skills-list">
+          <li>Python</li>
+          <li>JavaScript</li>
+          <li>C#</li>
+          <li>Vue.js, Bootstrap, Laravel</li>
+          <li>MS SQL, REST API, .NET Core</li>
+          <li>CNN, LSTM, GRU, TensorFlow, PyTorch</li>
         </ul>
-      </div>
-    </section>
-    <section>
-      <h2>Education</h2>
-      <div class="school">
-        <h3>Высший колледж «Astana Polytechnic»</h3>
-        <span class="date">2020 – 2024, техник-программист</span>
-      </div>
-      <div class="school">
-        <h3>AITU</h3>
-        <span class="date">2024 – 2027</span>
-      </div>
-      <div class="school">
-        <h3>Дополнительные курсы</h3>
+      </section>
+      <section>
+        <h2>Achievements</h2>
         <ul>
-          <li>Coursera: Machine Learning by Andrew Ng</li>
-          <li>Reinforcement Learning by University of Alberta</li>
-          <li>Convolution NN, Sequence Models by DeepLearning.ai</li>
-          <li>Сертификаты Udemy, Datacamp</li>
+          <li>1 место в региональном чемпионате WorldSkills Astana 2023</li>
+          <li>1 место в Хакатоне по кибербезопасности, Караганда 2024</li>
         </ul>
-      </div>
-    </section>
-    <section>
-      <h2>Skills</h2>
-      <ul class="skills-list">
-        <li>Python</li>
-        <li>JavaScript</li>
-        <li>C#</li>
-        <li>Vue.js, Bootstrap, Laravel</li>
-        <li>MS SQL, REST API, .NET Core</li>
-        <li>CNN, LSTM, GRU, TensorFlow, PyTorch</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Achievements</h2>
-      <ul>
-        <li>1 место в региональном чемпионате WorldSkills Astana 2023</li>
-        <li>1 место в Хакатоне по кибербезопасности, Караганда 2024</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Languages</h2>
-      <p>Казахский, русский, английский (IELTS 5, B1-B2)</p>
-    </section>
-    <section>
-      <h2>Hobbies</h2>
-      <p>3D печать, изучение исследовательских работ по нейронным сетям</p>
-    </section>
-  </main>
+      </section>
+      <section>
+        <h2>Certificates</h2>
+        <div class="certificates">
+          <img src="6874a88d0920693c7018202d.jpg" alt="Certificate 1" />
+          <img src="6874a88d0920693c7018202e.jpg" alt="Certificate 2" />
+          <img src="6874a88d0920693c7018202f.jpg" alt="Certificate 3" />
+          <img src="6874a88d0920693c70182030.jpg" alt="Certificate 4" />
+        </div>
+      </section>
+      <section>
+        <h2>Languages</h2>
+        <p>Казахский, русский, английский (IELTS 5, B1-B2)</p>
+      </section>
+      <section>
+        <h2>Hobbies</h2>
+        <p>3D печать, изучение исследовательских работ по нейронным сетям</p>
+      </section>
+    </main>
 
-  <footer>
-    <p class="container">&copy; 2024 Кембаев Мухамеджан Касенулы</p>
-  </footer>
-</body>
+    <footer>
+      <p class="container">&copy; 2024 Кембаев Мухамеджан Касенулы</p>
+    </footer>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   line-height: 1.6;
+  background: #121212;
+  color: #eee;
 }
 
 .container {
@@ -10,31 +12,62 @@ body {
   padding: 0 20px;
 }
 
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 header {
-  background-color: #333;
+  background: linear-gradient(135deg, #1e1e1e, #272727);
   color: #fff;
   padding: 20px 0;
   text-align: center;
+  border-bottom: 2px solid #39f;
 }
 
 header h1 {
   margin: 0;
 }
 
+.profile-photo {
+  width: 300px;
+  border-radius: 8px;
+  display: block;
+  margin: 0 auto 10px;
+}
+
+h2 {
+  color: #39f;
+  border-bottom: 1px solid #333;
+  padding-bottom: 5px;
+}
+
 .contact-info {
   margin: 5px 0 10px;
 }
 
-
 main section {
   margin-bottom: 20px;
+  animation: fadeInUp 0.6s ease both;
+  background: #1a1a1a;
+  padding: 20px;
+  border-radius: 8px;
+  margin-top: 20px;
 }
 
-.job, .school {
+.job,
+.school {
   margin-bottom: 10px;
 }
 
-.job .date, .school .date {
+.job .date,
+.school .date {
   font-style: italic;
   display: block;
 }
@@ -45,16 +78,35 @@ main section {
 }
 
 .skills-list li {
-  background: #f0f0f0;
+  background: #252525;
+  color: #fff;
   display: inline-block;
   margin: 5px 5px 0 0;
   padding: 5px 10px;
   border-radius: 4px;
 }
 
+.certificates {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.certificates img {
+  width: 100%;
+  border-radius: 8px;
+  transition: transform 0.3s;
+}
+
+.certificates img:hover {
+  transform: scale(1.05);
+}
+
 footer {
   text-align: center;
   padding: 10px 0;
-  background: #f7f7f7;
+  background: #111;
   margin-top: 20px;
+  color: #777;
 }


### PR DESCRIPTION
## Summary
- add profile photo to header
- showcase certificates gallery
- introduce fade-in animations and dark theme

## Testing
- `npx prettier --check index.html style.css`

------
https://chatgpt.com/codex/tasks/task_e_6874c5530014832aad7f90f9dc175ee5