### PR TITLE
Align photo to left and add research link

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,18 @@
   </head>
   <body>
     <header>
-      <div class="container">
+      <div class="container header-container">
         <img
           class="profile-photo"
           src="IMG_20230430_110132.jpg"
           alt="Profile Photo"
         />
-        <h1>Кембаев Мухамеджан Касенулы</h1>
-        <p class="contact-info">
-          г.Астана, Казахстан &middot; Родился 28.05.2004
-        </p>
+        <div class="header-text">
+          <h1>Кембаев Мухамеджан Касенулы</h1>
+          <p class="contact-info">
+            г.Астана, Казахстан &middot; Родился 28.05.2004
+          </p>
+        </div>
       </div>
     </header>
 
@@ -93,6 +95,14 @@
       <section>
         <h2>Languages</h2>
         <p>Казахский, русский, английский (IELTS 5, B1-B2)</p>
+      </section>
+      <section>
+        <h2>Research Papers</h2>
+        <p>
+          В 2025 году изучал научные статьи и делился ими в своём Telegram-
+          канале
+          <a href="https://t.me/arxiv_insight">t.me/arxiv_insight</a>.
+        </p>
       </section>
       <section>
         <h2>Hobbies</h2>

--- a/style.css
+++ b/style.css
@@ -27,8 +27,16 @@ header {
   background: linear-gradient(135deg, #1e1e1e, #272727);
   color: #fff;
   padding: 20px 0;
-  text-align: center;
   border-bottom: 2px solid #39f;
+}
+
+.header-container {
+  display: flex;
+  align-items: center;
+}
+
+.header-text {
+  margin-left: 20px;
 }
 
 header h1 {
@@ -36,10 +44,10 @@ header h1 {
 }
 
 .profile-photo {
-  width: 300px;
+  width: 150px;
   border-radius: 8px;
   display: block;
-  margin: 0 auto 10px;
+  margin: 0 20px 10px 0;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- restructure header layout to place profile photo on the left
- shrink profile photo to 150px width
- document research papers channel for 2025

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874c817ec10832aba91a70dafc8fd66